### PR TITLE
change git connection URL to use HTTPS instead of HTTP.. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/liquibase/liquibase-databricks.git</connection>
+        <connection>scm:git:https://github.com/liquibase/liquibase-databricks.git</connection>
         <url>https://github.com/liquibase/liquibase-databricks</url>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
... to improve security

Fix for Error: `Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project liquibase-databricks: Unable to commit files`

 https://github.com/liquibase/liquibase-databricks/actions/runs/6354762339/job/17317658988#step:5:277