### PR TITLE
[DAT-18567] DevOps :: liquibase-databricks terraform fails to recreate IT tests schema

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -42,8 +42,8 @@ jobs:
         working-directory: src/test/terraform
 
       - run: |
-          terraform import databricks_schema.test_harness main.liquibase_harness_test_ds
-          terraform taint databricks_schema.test_harness
+          terraform import databricks_schema.test_harness main.liquibase_harness_test_ds || true
+          terraform taint databricks_schema.test_harness || true
           terraform apply -auto-approve
         working-directory: src/test/terraform
 

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -42,7 +42,8 @@ jobs:
         working-directory: src/test/terraform
 
       - run: |
-          terraform taint databricks_sql_endpoint.this && terraform taint databricks_schema.test_harness
+          terraform import databricks_schema.test_harness main.liquibase_harness_test_ds
+          terraform taint databricks_schema.test_harness
           terraform apply -auto-approve
         working-directory: src/test/terraform
 

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -41,7 +41,9 @@ jobs:
       - run: terraform plan
         working-directory: src/test/terraform
 
-      - run: terraform apply -auto-approve
+      - run: |
+          terraform taint databricks_sql_endpoint.this && terraform taint databricks_schema.test_harness
+          terraform apply -auto-approve
         working-directory: src/test/terraform
 
       - name: Collect Databricks Config

--- a/src/test/terraform/auth.tf
+++ b/src/test/terraform/auth.tf
@@ -3,7 +3,7 @@ variable "DBX_HOST" {
 }
 
 variable "DBX_TOKEN" {
-  type  = string
+  type = string
 }
 
 # Initialize the Databricks Terraform provider.

--- a/src/test/terraform/dbsql_endpoint.tf
+++ b/src/test/terraform/dbsql_endpoint.tf
@@ -1,16 +1,8 @@
-resource "random_string" "suffix" {
-  length  = 8
-  special = false
-  upper   = false
-}
 resource "databricks_sql_endpoint" "this" {
-  name             = "Databricks Liquibase Test Harness Endpoint-${random_string.suffix.result}"
+  name             = "Databricks Liquibase Test Harness Endpoint"
   cluster_size     = "Small"
   max_num_clusters = 1
   warehouse_type   = "PRO"
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 output "endpoint_url" {

--- a/src/test/terraform/dbsql_endpoint.tf
+++ b/src/test/terraform/dbsql_endpoint.tf
@@ -1,8 +1,16 @@
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
 resource "databricks_sql_endpoint" "this" {
-  name             = "Databricks Liquibase Test Harness Endpoint"
+  name             = "Databricks Liquibase Test Harness Endpoint-${random_string.suffix.result}"
   cluster_size     = "Small"
   max_num_clusters = 1
   warehouse_type   = "PRO"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 output "endpoint_url" {

--- a/src/test/terraform/dbsql_endpoint.tf
+++ b/src/test/terraform/dbsql_endpoint.tf
@@ -1,8 +1,16 @@
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
 resource "databricks_sql_endpoint" "this" {
-  name             = "Databricks Liquibase Test Harness Endpoint"
+  name             = "Databricks Liquibase Test Harness Endpoint-${random_string.suffix.result}"
   cluster_size     = "Small"
   max_num_clusters = 1
-  warehouse_type = "PRO"
+  warehouse_type   = "PRO"
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 output "endpoint_url" {

--- a/src/test/terraform/schema.auto.tfvars
+++ b/src/test/terraform/schema.auto.tfvars
@@ -1,3 +1,3 @@
-TF_VAR_TEST_CATALOG = "main"
-TF_VAR_TEST_SCHEMA = "liquibase_harness_test_ds"
+TF_VAR_TEST_CATALOG  = "main"
+TF_VAR_TEST_SCHEMA   = "liquibase_harness_test_ds"
 schema_force_destroy = true

--- a/src/test/terraform/schema.tf
+++ b/src/test/terraform/schema.tf
@@ -1,25 +1,25 @@
 variable "TF_VAR_TEST_SCHEMA" {
   description = "Name of Liquibase test harness database"
-  type = string
-  default = "liquibase_harness_test_ds"
+  type        = string
+  default     = "liquibase_harness_test_ds"
 }
 
 
 variable "TF_VAR_TEST_CATALOG" {
   description = "Catalog of liquibase testing database"
-  type = string
-  default = "main"
+  type        = string
+  default     = "main"
 }
 
 variable "schema_force_destroy" {
-  type = bool
+  type    = bool
   default = true
 }
 
 resource "databricks_schema" "test_harness" {
-  catalog_name = var.TF_VAR_TEST_CATALOG
-  name = var.TF_VAR_TEST_SCHEMA
-  comment = "This database is for liquibase test harness"
+  catalog_name  = var.TF_VAR_TEST_CATALOG
+  name          = var.TF_VAR_TEST_SCHEMA
+  comment       = "This database is for liquibase test harness"
   force_destroy = var.schema_force_destroy
   properties = {
     purpose = "testing"


### PR DESCRIPTION
Force recreation by changing the endpoint name dynamically. It will trigger Terraform to destroy the existing resource and create a new one. This will ensure that a new SQL endpoint is created each time you apply the Terraform configuration, as the name will always be unique.

🔧 (auth.tf): Update type assignment formatting for DBX_TOKEN variablefor consistency
✨ (dbsql_endpoint.tf): Add random suffix to endpoint name for uniqueness
♻️ (schema.auto.tfvars): Align TF_VAR_TEST_CATALOG and TF_VAR_TEST_SCHEMA assignments for consistency
♻️ (schema.tf): Refactor type and default assignments for TF_VAR_TEST_SCHEMA, TF_VAR_TEST_CATALOG, and schema_force_destroy variables for consistency