### PR TITLE
DAT-18792: added cluster by support for snapshot and diff table related change types

### DIFF
--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingTableChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingTableChangeGeneratorDatabricks.java
@@ -12,8 +12,12 @@ import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Table;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class MissingTableChangeGeneratorDatabricks extends MissingTableChangeGenerator {
 
+    private static final String CLUSTERING_INFORMATION_TBL_PROPERTY_START = "clusteringColumns=[[";
 
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
@@ -51,6 +55,13 @@ public class MissingTableChangeGeneratorDatabricks extends MissingTableChangeGen
         createTableChangeDatabricks.setRemarks(temp.getRemarks());
         createTableChangeDatabricks.setIfNotExists(temp.getIfNotExists());
         createTableChangeDatabricks.setRowDependencies(temp.getRowDependencies());
+        if(extendedTableProperties.getTblProperties().contains(CLUSTERING_INFORMATION_TBL_PROPERTY_START)) {
+            //This approach should be rewritten after implementing tblProperties map parsing to Map struct collection
+            String tblProperties = extendedTableProperties.getTblProperties();
+            createTableChangeDatabricks.setClusterColumns(parseClusterColumns(tblProperties));
+            //Remove clusteringColumns property from tblProperties
+            extendedTableProperties.setTblProperties(tblProperties.replace(getClusteringColumnsSubstring(tblProperties), ""));
+        }
 
         createTableChangeDatabricks.setExtendedTableProperties(extendedTableProperties);
         return createTableChangeDatabricks;
@@ -59,5 +70,45 @@ public class MissingTableChangeGeneratorDatabricks extends MissingTableChangeGen
     @Override
     protected CreateTableChange createCreateTableChange() {
         return new CreateTableChangeDatabricks();
+    }
+
+    /**
+     * There might be 2 edge cases with table properties map:
+     *      <ul><li>User specified a custom tblProperty that appears prior databricks internal managed
+     *          clusteringColumns property and this custom tblProperty contains string snippet 'clusteringColumns=[['.
+     *          Pattern and matcher would process properties incorrect if there was present structure ["anyString"]
+     *          in between string snippet 'clusteringColumns=[[' and actual databricks managed property
+     *          clusteringColumns.
+     *      <li>User specified a custom table property that contains string snippet 'clusteringColumns=' and there are
+     *          no clustering configured on the table.<ul/>
+     * @param  tblProperties
+     *         The tblProperties map in a raw string format that returns as part of result set of
+     *         DESCRIBE TABLE EXTENDED query.
+     * @return Coma separated clustering columns extracted from tblProperties
+     * */
+    private String parseClusterColumns(String tblProperties) {
+        //  Actual pattern - "\[\"([^\"]*)\"\]"
+        Pattern pattern = Pattern.compile("\\[\\\"([^\\\"]*)\\\"\\]");
+        String clusteringColumnsRaw = getClusteringColumnsSubstring(tblProperties);
+        StringBuilder clusterColumnNames = new StringBuilder();
+        try{
+            Matcher matcher = pattern.matcher(clusteringColumnsRaw);
+            for (int i = 0; matcher.find(); i++) {
+                //getting first matching group to avoid quotes and brackets
+                String group = matcher.group(1);
+                clusterColumnNames.append(i == 0 ? "" : ",").append(group);
+            }
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
+
+        return clusterColumnNames.toString();
+    }
+
+    private String getClusteringColumnsSubstring(String tblProperties) {
+        int clusterColumnsStartIndex = tblProperties.indexOf(CLUSTERING_INFORMATION_TBL_PROPERTY_START);
+        // To avoid appearance anywhere before clusteringColumns property we are specifying clusterColumnsStartIndex
+        // to start search from for end index snippet.
+        return tblProperties.substring(clusterColumnsStartIndex, tblProperties.indexOf("\"]],", clusterColumnsStartIndex) + 4);
     }
 }

--- a/src/test/resources/liquibase/harness/change/changelogs/databricks/createClusteredTableNew.json
+++ b/src/test/resources/liquibase/harness/change/changelogs/databricks/createClusteredTableNew.json
@@ -20,9 +20,15 @@
                     "name": "test_new",
                     "type": "int"
                   }
+                },
+                {
+                  "column": {
+                    "name": "test_present_new",
+                    "type": "int"
+                  }
                 }
               ],
-              "clusterColumns": "test_id,test_new"
+              "clusterColumns": "test_id,test_new,test_present_new"
             }
           }
         ],
@@ -47,6 +53,11 @@
                 {
                   "column": {
                     "name": "test_id"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "test_present_new`"
                   }
                 }
               ]

--- a/src/test/resources/liquibase/harness/change/changelogs/databricks/createClusteredTableNew.xml
+++ b/src/test/resources/liquibase/harness/change/changelogs/databricks/createClusteredTableNew.xml
@@ -13,7 +13,8 @@
         <createTable tableName="test_table_clustered_new" >
             <column name="test_id" type="int" />
             <column name="test_new" type="int"/>
-            <databricks:clusterColumns>test_id,test_new</databricks:clusterColumns>
+            <column name="test_present_new" type="int"/>
+            <databricks:clusterColumns>test_id,test_new,test_present_new</databricks:clusterColumns>
         </createTable>
         <rollback>
             <!-- The dropTable will drop a full table whether it has clustered columns or not. -->
@@ -23,6 +24,7 @@
     <changeSet id="2" author="your.name">
         <databricks:alterCluster tableName="test_table_clustered_new">
             <databricks:column name="test_id"/>
+            <databricks:column name="test_present_new"/>
         </databricks:alterCluster>
         <rollback/>
     </changeSet>

--- a/src/test/resources/liquibase/harness/change/changelogs/databricks/createClusteredTableNew.yaml
+++ b/src/test/resources/liquibase/harness/change/changelogs/databricks/createClusteredTableNew.yaml
@@ -12,7 +12,10 @@ databaseChangeLog:
               - column:
                   name: test_new
                   type: int
-            clusterColumns: test_id, test_new
+              - column:
+                  name: test_present_new
+                  type: int
+            clusterColumns: test_id, test_new, test_present_new
       rollback:
         dropTable:
           tableName: test_table_clustered_new
@@ -25,6 +28,8 @@ databaseChangeLog:
             columns:
               - column:
                   name: test_id
+              - column:
+                  name: test_present_new
       rollback:
         empty
   - changeSet:

--- a/src/test/resources/liquibase/harness/change/expectedSnapshot/databricks/createClusteredTableNew.json
+++ b/src/test/resources/liquibase/harness/change/expectedSnapshot/databricks/createClusteredTableNew.json
@@ -1,2 +1,25 @@
 {
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "test_table_clustered_new"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "test_id"
+          }
+        },
+        {
+          "column": {
+            "name": "test_present_new"
+          }
+        }
+      ]
+    }
+  }
 }

--- a/src/test/resources/liquibase/harness/change/expectedSql/databricks/createClusteredTableNew.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/databricks/createClusteredTableNew.sql
@@ -1,3 +1,3 @@
-CREATE TABLE main.liquibase_harness_test_ds.test_table_clustered_new (test_id INT, test_new INT) USING delta TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported', 'delta.columnMapping.mode' = 'name', 'delta.enableDeletionVectors' = true) CLUSTER BY (test_id, test_new)
-ALTER TABLE main.liquibase_harness_test_ds.test_table_clustered_new CLUSTER BY (test_id)
+CREATE TABLE main.liquibase_harness_test_ds.test_table_clustered_new (test_id INT, test_new INT, test_present_new INT) USING delta TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported', 'delta.columnMapping.mode' = 'name', 'delta.enableDeletionVectors' = true) CLUSTER BY (test_id, test_new, test_present_new)
+ALTER TABLE main.liquibase_harness_test_ds.test_table_clustered_new CLUSTER BY (test_id,test_present_new)
 ALTER TABLE main.liquibase_harness_test_ds.test_table_clustered_new DROP COLUMN test_new


### PR DESCRIPTION
Tested following liquibase commands:

- diff
- diff-changelog
- snapshot
- generate-changelog

Changelog generates with present CLUSTER BY part with appropriate columns. Tested case with 1 and 2 clustering columns.
Generated changeset example:
```
    <changeSet author="msav1 (generated)" id="1728984464968-4">
        <databricks:createTable clusterColumns="test_id,test_present_new" tableName="test_table_clustered_new">
            <column name="test_id" type="INT"/>
            <column name="test_present_new" type="INT"/>
            <databricks:extendedTableProperties tableLocation="s3://databricks-test-harness-metastore/c93bad90-fc3e-4083-a910-1cad48d283f2/tables/3b4b3312-cd20-41d1-9d74-451be370869f" tblProperties="delta.checkpoint.writeStatsAsJson=false,delta.checkpoint.writeStatsAsStruct=true,delta.checkpointPolicy=v2,delta.columnMapping.maxColumnId=3,delta.columnMapping.mode=name,delta.enableDeletionVectors=true,delta.enableRowTracking=true,delta.feature.allowColumnDefaults=supported,delta.feature.clustering=supported,delta.feature.columnMapping=supported,delta.feature.deletionVectors=supported,delta.feature.domainMetadata=supported,delta.feature.rowTracking=supported,delta.feature.v2Checkpoint=supported,delta.minReaderVersion=3,delta.minWriterVersion=7,delta.rowTracking.materializedRowCommitVersionColumnName=_row-commit-version-col-f039a2c1-7756-4597-9259-825d27ddce58,delta.rowTracking.materializedRowIdColumnName=_row-id-col-4af75f6c-2d74-4fcf-bc2b-8a2ddce45ef4"/>
        </databricks:createTable>
    </changeSet>
```