### PR TITLE
feat(DAT-18853): Add custom diff change generator for Databricks

### DIFF
--- a/src/main/java/liquibase/ext/databricks/change/AbstractAlterPropertiesChangeDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/change/AbstractAlterPropertiesChangeDatabricks.java
@@ -81,4 +81,9 @@ public abstract class AbstractAlterPropertiesChangeDatabricks extends AbstractCh
     public UnsetExtendedTableProperties getUnsetExtendedTableProperties() {
         return unsetExtendedTableProperties;
     }
+
+    @Override
+    public String getSerializedObjectNamespace() {
+        return "http://www.liquibase.org/xml/ns/databricks";
+    }
 }

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTableChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTableChangeGeneratorDatabricks.java
@@ -7,7 +7,7 @@ import liquibase.diff.ObjectDifferences;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
 import liquibase.diff.output.changelog.core.ChangedTableChangeGenerator;
-import liquibase.ext.databricks.change.alterTableProperties.AlterTablePropertiesChangeDatabricks;
+import liquibase.ext.databricks.change.AbstractAlterPropertiesChangeDatabricks;
 import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Table;
@@ -34,13 +34,13 @@ public class ChangedTableChangeGeneratorDatabricks extends ChangedTableChangeGen
         Change[] changes = super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
         for (Difference difference : differences.getDifferences()) {
             if (difference.getField().equals("tblProperties")) {
-                AlterTablePropertiesChangeDatabricks change = getAlterTablePropertiesChangeDatabricks((Table) changedObject, control, difference);
+                AbstractAlterPropertiesChangeDatabricks[] change = getAlterTablePropertiesChangeDatabricks((Table) changedObject, control, difference);
 
                 if (changes == null || changes.length == 0) {
-                    changes = new Change[] {change};
+                    changes = change;
                 } else {
-                    changes = Arrays.copyOf(changes, changes.length + 1);
-                    changes[changes.length - 1] = change;
+                    changes = Arrays.copyOf(changes, changes.length + change.length);
+                    System.arraycopy(change, 0, changes, changes.length - change.length, change.length);
                 }
             }
         }

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTableChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTableChangeGeneratorDatabricks.java
@@ -1,0 +1,106 @@
+package liquibase.ext.databricks.diff.output.changelog;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.Difference;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.diff.output.changelog.core.ChangedTableChangeGenerator;
+import liquibase.ext.databricks.change.alterTableProperties.AlterTablePropertiesChangeDatabricks;
+import liquibase.ext.databricks.change.alterTableProperties.SetExtendedTableProperties;
+import liquibase.ext.databricks.change.alterTableProperties.UnsetExtendedTableProperties;
+import liquibase.ext.databricks.database.DatabricksDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Table;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Custom diff change generator for Databricks
+ */
+public class ChangedTableChangeGeneratorDatabricks extends ChangedTableChangeGenerator {
+
+    private static final String SPLIT_ON_COMMAS = ",(?=(?:[^\"]*\"[^\"]*\")*[^\"$])";
+    private static final String SPLIT_ON_EQUALS = "=(?=(?:[^\"]*\"[^\"]*\")*[^\"$])";
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (database instanceof DatabricksDatabase && super.getPriority(objectType, database) > PRIORITY_NONE) {
+            return PRIORITY_DATABASE;
+        }
+        return PRIORITY_NONE;
+    }
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        Change[] changes = super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+        for (Difference difference : differences.getDifferences()) {
+            if (difference.getField().equals("tblProperties")) {
+                AlterTablePropertiesChangeDatabricks change = getAlterTablePropertiesChangeDatabricks((Table) changedObject, control, difference);
+
+                if (changes == null || changes.length == 0) {
+                    changes = new Change[] {change};
+                } else {
+                    changes = Arrays.copyOf(changes, changes.length + 1);
+                    changes[changes.length - 1] = change;
+                }
+            }
+        }
+        return changes;
+    }
+
+    /**
+     * Get the AlterTablePropertiesChangeDatabricks changes
+     */
+    private AlterTablePropertiesChangeDatabricks getAlterTablePropertiesChangeDatabricks(Table changedObject, DiffOutputControl control, Difference difference) {
+        String referenceValue = difference.getReferenceValue() == null ? "" : difference.getReferenceValue().toString();
+        Map<String, String> referencedValuesMap = Arrays.stream(referenceValue.split(SPLIT_ON_COMMAS))
+                .map(s -> s.split(SPLIT_ON_EQUALS))
+                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+
+        String comparedValue = difference.getComparedValue() == null ? "" : difference.getComparedValue().toString();
+
+        Map<String, String> comparedValuesMap = Arrays.stream(comparedValue.split(SPLIT_ON_COMMAS))
+                .map(s -> s.split(SPLIT_ON_EQUALS))
+                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+
+        Map<String, String> addPropertiesMap = new HashMap<>();
+        //first we add the missing or changed properties
+        referencedValuesMap.forEach((key, value) -> {
+            if (!comparedValuesMap.containsKey(key) || !comparedValuesMap.get(key).equals(value)) {
+                addPropertiesMap.put(key, value);
+            }
+        });
+        //then we remove the properties that are not in the reference
+        Map<String, String> removePropertiesMap = comparedValuesMap.entrySet().stream()
+                .filter(entry -> !referencedValuesMap.containsKey(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        AlterTablePropertiesChangeDatabricks change = new AlterTablePropertiesChangeDatabricks();
+        SetExtendedTableProperties setExtendedTableProperties = new SetExtendedTableProperties();
+        setExtendedTableProperties.setTblProperties(addPropertiesMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")));
+        change.setSetExtendedTableProperties(setExtendedTableProperties);
+
+        UnsetExtendedTableProperties unsetExtendedTableProperties = new UnsetExtendedTableProperties();
+        unsetExtendedTableProperties.setTblProperties(String.join(",", removePropertiesMap.keySet()));
+        change.setUnsetExtendedTableProperties(unsetExtendedTableProperties);
+        setTableProperties(changedObject, control, change);
+        return change;
+    }
+
+    private void setTableProperties(Table table, DiffOutputControl control, AlterTablePropertiesChangeDatabricks change) {
+        change.setTableName(table.getName());
+        if (control.getIncludeCatalog()) {
+            change.setCatalogName(table.getSchema().getCatalogName());
+        }
+
+        if (control.getIncludeSchema()) {
+            change.setSchemaName(table.getSchema().getName());
+        }
+    }
+
+}

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
@@ -1,0 +1,100 @@
+package liquibase.ext.databricks.diff.output.changelog;
+
+import liquibase.diff.Difference;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.ext.databricks.change.AbstractAlterPropertiesChangeDatabricks;
+import liquibase.ext.databricks.change.alterTableProperties.AlterTablePropertiesChangeDatabricks;
+import liquibase.ext.databricks.change.alterTableProperties.SetExtendedTableProperties;
+import liquibase.ext.databricks.change.alterTableProperties.UnsetExtendedTableProperties;
+import liquibase.ext.databricks.change.alterViewProperties.AlterViewPropertiesChangeDatabricks;
+import liquibase.structure.AbstractDatabaseObject;
+import liquibase.structure.core.Table;
+import liquibase.structure.core.View;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for changed table properties diff
+ */
+public class ChangedTblPropertiesUtil {
+
+
+    private static final String SPLIT_ON_COMMAS = ",(?=(?:[^\"]*\"[^\"]*\")*[^\"$])";
+    private static final String SPLIT_ON_EQUALS = "=(?=(?:[^\"]*\"[^\"]*\")*[^\"$])";
+
+    private ChangedTblPropertiesUtil() {
+    }
+
+    /**
+     * Get the AlterViewPropertiesChangeDatabricks changes
+     */
+    static AlterViewPropertiesChangeDatabricks getAlterViewPropertiesChangeDatabricks(View changedObject, DiffOutputControl control, Difference difference) {
+        AlterViewPropertiesChangeDatabricks change = (AlterViewPropertiesChangeDatabricks) getAbstractTablePropertiesChangeDatabricks(changedObject, control, difference, AlterViewPropertiesChangeDatabricks.class);
+        change.setViewName(changedObject.getName());
+        return change;
+    }
+
+    /**
+     * Get the AlterTablePropertiesChangeDatabricks changes
+     */
+    static AlterTablePropertiesChangeDatabricks getAlterTablePropertiesChangeDatabricks(Table changedObject, DiffOutputControl control, Difference difference) {
+        AlterTablePropertiesChangeDatabricks change = (AlterTablePropertiesChangeDatabricks) getAbstractTablePropertiesChangeDatabricks(changedObject, control, difference, AlterTablePropertiesChangeDatabricks.class);
+        change.setTableName(changedObject.getName());
+        return change;
+    }
+
+    private static AbstractAlterPropertiesChangeDatabricks getAbstractTablePropertiesChangeDatabricks(AbstractDatabaseObject changedObject, DiffOutputControl control, Difference difference, Class<? extends AbstractAlterPropertiesChangeDatabricks> clazz) {
+        String referenceValue = difference.getReferenceValue() == null ? "" : difference.getReferenceValue().toString();
+        Map<String, String> referencedValuesMap = Arrays.stream(referenceValue.split(SPLIT_ON_COMMAS))
+                .map(s -> s.split(SPLIT_ON_EQUALS))
+                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+
+        String comparedValue = difference.getComparedValue() == null ? "" : difference.getComparedValue().toString();
+
+        Map<String, String> comparedValuesMap = Arrays.stream(comparedValue.split(SPLIT_ON_COMMAS))
+                .map(s -> s.split(SPLIT_ON_EQUALS))
+                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+
+        Map<String, String> addPropertiesMap = new HashMap<>();
+        //first we add the missing or changed properties
+        referencedValuesMap.forEach((key, value) -> {
+            if (!comparedValuesMap.containsKey(key) || !comparedValuesMap.get(key).equals(value)) {
+                addPropertiesMap.put(key, value);
+            }
+        });
+        //then we remove the properties that are not in the reference
+        Map<String, String> removePropertiesMap = comparedValuesMap.entrySet().stream()
+                .filter(entry -> !referencedValuesMap.containsKey(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        AbstractAlterPropertiesChangeDatabricks change = null;
+        try {
+            change = clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new UnexpectedLiquibaseException("Reflection error", e);
+        }
+        SetExtendedTableProperties setExtendedTableProperties = new SetExtendedTableProperties();
+        setExtendedTableProperties.setTblProperties(addPropertiesMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")));
+        change.setSetExtendedTableProperties(setExtendedTableProperties);
+
+        UnsetExtendedTableProperties unsetExtendedTableProperties = new UnsetExtendedTableProperties();
+        unsetExtendedTableProperties.setTblProperties(String.join(",", removePropertiesMap.keySet()));
+        change.setUnsetExtendedTableProperties(unsetExtendedTableProperties);
+        setCatalogAndSchema(changedObject, control, change);
+        return change;
+    }
+
+    private static void setCatalogAndSchema(AbstractDatabaseObject table, DiffOutputControl control, AbstractAlterPropertiesChangeDatabricks change) {
+        if (control.getIncludeCatalog()) {
+            change.setCatalogName(table.getSchema().getCatalogName());
+        }
+
+        if (control.getIncludeSchema()) {
+            change.setSchemaName(table.getSchema().getName());
+        }
+    }
+}

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static liquibase.ext.databricks.snapshot.jvm.TableSnapshotGeneratorDatabricks.PROPERTIES_STOP_LIST;
+
 /**
  * Utility class for changed table properties diff
  */
@@ -50,18 +52,8 @@ public class ChangedTblPropertiesUtil {
 
     static AbstractAlterPropertiesChangeDatabricks[] getAbstractTablePropertiesChangeDatabricks(AbstractDatabaseObject changedObject, DiffOutputControl control, Difference difference, Class<? extends AbstractAlterPropertiesChangeDatabricks> clazz) {
         AbstractAlterPropertiesChangeDatabricks[] changes = new AbstractAlterPropertiesChangeDatabricks[0];
-        String referenceValue = difference.getReferenceValue() == null ? "" : difference.getReferenceValue().toString();
-        Map<String, String> referencedValuesMap = Arrays.stream(referenceValue.split(SPLIT_ON_COMMAS))
-                .map(s -> s.split(SPLIT_ON_EQUALS))
-                .filter(a -> a.length > 1)
-                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
-
-        String comparedValue = difference.getComparedValue() == null ? "" : difference.getComparedValue().toString();
-
-        Map<String, String> comparedValuesMap = Arrays.stream(comparedValue.split(SPLIT_ON_COMMAS))
-                .map(s -> s.split(SPLIT_ON_EQUALS))
-                .filter(a -> a.length > 1)
-                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+        Map<String, String> referencedValuesMap = convertToMap(difference.getReferenceValue());
+        Map<String, String> comparedValuesMap = convertToMap(difference.getComparedValue());
 
         Map<String, String> addPropertiesMap = new HashMap<>();
         //first we add the missing or changed properties
@@ -97,6 +89,16 @@ public class ChangedTblPropertiesUtil {
         }
 
         return changes;
+    }
+
+    private static Map<String, String> convertToMap(Object referenceValueObject) {
+        String referenceValue = referenceValueObject == null ? "" : referenceValueObject.toString();
+         return Arrays.stream(referenceValue.split(SPLIT_ON_COMMAS))
+                .map(s -> s.split(SPLIT_ON_EQUALS))
+                .filter(a -> a.length > 1)
+                 .map(a -> new String[]{a[0].trim(), a[1].trim()})
+                .filter(a -> !PROPERTIES_STOP_LIST.contains(a[0].replace("'", "")))
+                .collect(Collectors.toMap(a -> a[0], a -> a[1]));
     }
 
     private static AbstractAlterPropertiesChangeDatabricks getAbstractAlterPropertiesChangeDatabricks(AbstractDatabaseObject changedObject, DiffOutputControl control, Class<? extends AbstractAlterPropertiesChangeDatabricks> clazz) {

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static liquibase.ext.databricks.snapshot.jvm.TableSnapshotGeneratorDatabricks.PROPERTIES_STOP_LIST;
-
 /**
  * Utility class for changed table properties diff
  */
@@ -97,7 +95,7 @@ public class ChangedTblPropertiesUtil {
                 .map(s -> s.split(SPLIT_ON_EQUALS))
                 .filter(a -> a.length > 1)
                  .map(a -> new String[]{a[0].trim(), a[1].trim()})
-                .filter(a -> !PROPERTIES_STOP_LIST.contains(a[0].replace("'", "")))
+                .filter(a -> !a[0].replace("'", "").matches("^delta.+"))
                 .collect(Collectors.toMap(a -> a[0], a -> a[1]));
     }
 

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
@@ -79,13 +79,18 @@ public class ChangedTblPropertiesUtil {
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException("Reflection error", e);
         }
-        SetExtendedTableProperties setExtendedTableProperties = new SetExtendedTableProperties();
-        setExtendedTableProperties.setTblProperties(addPropertiesMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")));
-        change.setSetExtendedTableProperties(setExtendedTableProperties);
+        if (!addPropertiesMap.isEmpty()) {
+            SetExtendedTableProperties setExtendedTableProperties = new SetExtendedTableProperties();
+            setExtendedTableProperties.setTblProperties(addPropertiesMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")));
+            change.setSetExtendedTableProperties(setExtendedTableProperties);
+        }
 
-        UnsetExtendedTableProperties unsetExtendedTableProperties = new UnsetExtendedTableProperties();
-        unsetExtendedTableProperties.setTblProperties(String.join(",", removePropertiesMap.keySet()));
-        change.setUnsetExtendedTableProperties(unsetExtendedTableProperties);
+        if (!removePropertiesMap.isEmpty()) {
+            UnsetExtendedTableProperties unsetExtendedTableProperties = new UnsetExtendedTableProperties();
+            unsetExtendedTableProperties.setTblProperties(String.join(",", removePropertiesMap.keySet()));
+            change.setUnsetExtendedTableProperties(unsetExtendedTableProperties);
+        }
+
         setCatalogAndSchema(changedObject, control, change);
         return change;
     }

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtil.java
@@ -47,16 +47,18 @@ public class ChangedTblPropertiesUtil {
         return change;
     }
 
-    private static AbstractAlterPropertiesChangeDatabricks getAbstractTablePropertiesChangeDatabricks(AbstractDatabaseObject changedObject, DiffOutputControl control, Difference difference, Class<? extends AbstractAlterPropertiesChangeDatabricks> clazz) {
+    static AbstractAlterPropertiesChangeDatabricks getAbstractTablePropertiesChangeDatabricks(AbstractDatabaseObject changedObject, DiffOutputControl control, Difference difference, Class<? extends AbstractAlterPropertiesChangeDatabricks> clazz) {
         String referenceValue = difference.getReferenceValue() == null ? "" : difference.getReferenceValue().toString();
         Map<String, String> referencedValuesMap = Arrays.stream(referenceValue.split(SPLIT_ON_COMMAS))
                 .map(s -> s.split(SPLIT_ON_EQUALS))
+                .filter(a -> a.length > 1)
                 .collect(Collectors.toMap(a -> a[0], a -> a[1]));
 
         String comparedValue = difference.getComparedValue() == null ? "" : difference.getComparedValue().toString();
 
         Map<String, String> comparedValuesMap = Arrays.stream(comparedValue.split(SPLIT_ON_COMMAS))
                 .map(s -> s.split(SPLIT_ON_EQUALS))
+                .filter(a -> a.length > 1)
                 .collect(Collectors.toMap(a -> a[0], a -> a[1]));
 
         Map<String, String> addPropertiesMap = new HashMap<>();

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedViewChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedViewChangeGeneratorDatabricks.java
@@ -7,6 +7,7 @@ import liquibase.diff.ObjectDifferences;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
 import liquibase.diff.output.changelog.core.ChangedViewChangeGenerator;
+import liquibase.ext.databricks.change.AbstractAlterPropertiesChangeDatabricks;
 import liquibase.ext.databricks.change.alterViewProperties.AlterViewPropertiesChangeDatabricks;
 import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.structure.DatabaseObject;
@@ -32,13 +33,13 @@ public class ChangedViewChangeGeneratorDatabricks extends ChangedViewChangeGener
         Change[] changes = null;
         for (Difference difference : differences.getDifferences()) {
             if (difference.getField().equals("tblProperties")) {
-                AlterViewPropertiesChangeDatabricks change = getAlterViewPropertiesChangeDatabricks((View) changedObject, control, difference);
+                AbstractAlterPropertiesChangeDatabricks[] change = getAlterViewPropertiesChangeDatabricks((View) changedObject, control, difference);
 
                 if (changes == null) {
-                    changes = new Change[] {change};
+                    changes = change;
                 } else {
-                    changes = Arrays.copyOf(changes, changes.length + 1);
-                    changes[changes.length - 1] = change;
+                    changes = Arrays.copyOf(changes, changes.length + change.length);
+                    System.arraycopy(change, 0, changes, changes.length - change.length, change.length);
                 }
                 differences.removeDifference("tblProperties");
             }

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedViewChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/ChangedViewChangeGeneratorDatabricks.java
@@ -6,20 +6,18 @@ import liquibase.diff.Difference;
 import liquibase.diff.ObjectDifferences;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
-import liquibase.diff.output.changelog.core.ChangedTableChangeGenerator;
-import liquibase.ext.databricks.change.alterTableProperties.AlterTablePropertiesChangeDatabricks;
+import liquibase.diff.output.changelog.core.ChangedViewChangeGenerator;
+import liquibase.ext.databricks.change.alterViewProperties.AlterViewPropertiesChangeDatabricks;
 import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.structure.DatabaseObject;
-import liquibase.structure.core.Table;
+import liquibase.structure.core.View;
 
 import java.util.Arrays;
 
-import static liquibase.ext.databricks.diff.output.changelog.ChangedTblPropertiesUtil.getAlterTablePropertiesChangeDatabricks;
+import static liquibase.ext.databricks.diff.output.changelog.ChangedTblPropertiesUtil.getAlterViewPropertiesChangeDatabricks;
 
-/**
- * Custom diff change generator for Databricks
- */
-public class ChangedTableChangeGeneratorDatabricks extends ChangedTableChangeGenerator {
+
+public class ChangedViewChangeGeneratorDatabricks extends ChangedViewChangeGenerator {
 
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
@@ -34,7 +32,7 @@ public class ChangedTableChangeGeneratorDatabricks extends ChangedTableChangeGen
         Change[] changes = super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
         for (Difference difference : differences.getDifferences()) {
             if (difference.getField().equals("tblProperties")) {
-                AlterTablePropertiesChangeDatabricks change = getAlterTablePropertiesChangeDatabricks((Table) changedObject, control, difference);
+                AlterViewPropertiesChangeDatabricks change = getAlterViewPropertiesChangeDatabricks((View) changedObject, control, difference);
 
                 if (changes == null || changes.length == 0) {
                     changes = new Change[] {change};
@@ -46,5 +44,4 @@ public class ChangedTableChangeGeneratorDatabricks extends ChangedTableChangeGen
         }
         return changes;
     }
-
 }

--- a/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
@@ -23,7 +23,7 @@ public class TableSnapshotGeneratorDatabricks extends TableSnapshotGenerator {
     private static final String TBL_PROPERTIES = "tblProperties";
     private static final String CLUSTER_COLUMNS = "clusteringColumns";
     private static final String DETAILED_TABLE_INFORMATION_NODE = "# Detailed Table Information";
-    private static final List<String> TBL_PROPERTIES_STOP_LIST = Arrays.asList(
+    protected  static final List<String> PROPERTIES_STOP_LIST = Arrays.asList(
             "delta.columnMapping.maxColumnId",
             "delta.rowTracking.materializedRowCommitVersionColumnName",
             "delta.rowTracking.materializedRowIdColumnName",
@@ -62,7 +62,7 @@ public class TableSnapshotGeneratorDatabricks extends TableSnapshotGenerator {
             Map<String, String> tblProperties = getTblPropertiesMap(database, example.getName());
             if (tblProperties.containsKey(CLUSTER_COLUMNS)) {
                 // removing clusterColumns and other properties which are not allowed in create/alter table statements
-                TBL_PROPERTIES_STOP_LIST.forEach(tblProperties::remove);
+                PROPERTIES_STOP_LIST.forEach(tblProperties::remove);
                 table.setAttribute(CLUSTER_COLUMNS, sanitizeClusterColumns(tblProperties.remove(CLUSTER_COLUMNS)));
             }
             table.setAttribute(TBL_PROPERTIES, getTblPropertiesString(tblProperties));

--- a/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
@@ -23,7 +23,7 @@ public class TableSnapshotGeneratorDatabricks extends TableSnapshotGenerator {
     private static final String TBL_PROPERTIES = "tblProperties";
     private static final String CLUSTER_COLUMNS = "clusteringColumns";
     private static final String DETAILED_TABLE_INFORMATION_NODE = "# Detailed Table Information";
-    protected  static final List<String> PROPERTIES_STOP_LIST = Arrays.asList(
+    public  static final List<String> PROPERTIES_STOP_LIST = Arrays.asList(
             "delta.columnMapping.maxColumnId",
             "delta.rowTracking.materializedRowCommitVersionColumnName",
             "delta.rowTracking.materializedRowIdColumnName",

--- a/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
@@ -23,7 +23,7 @@ public class TableSnapshotGeneratorDatabricks extends TableSnapshotGenerator {
     private static final String TBL_PROPERTIES = "tblProperties";
     private static final String CLUSTER_COLUMNS = "clusteringColumns";
     private static final String DETAILED_TABLE_INFORMATION_NODE = "# Detailed Table Information";
-    public  static final List<String> PROPERTIES_STOP_LIST = Arrays.asList(
+    private static final List<String> PROPERTIES_STOP_LIST = Arrays.asList(
             "delta.columnMapping.maxColumnId",
             "delta.rowTracking.materializedRowCommitVersionColumnName",
             "delta.rowTracking.materializedRowIdColumnName",

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -1,2 +1,3 @@
 liquibase.ext.databricks.diff.output.changelog.MissingTableChangeGeneratorDatabricks
 liquibase.ext.databricks.diff.output.changelog.MissingViewChangeGeneratorDatabricks
+liquibase.ext.databricks.diff.output.changelog.ChangedTableChangeGeneratorDatabricks

--- a/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -1,3 +1,4 @@
 liquibase.ext.databricks.diff.output.changelog.MissingTableChangeGeneratorDatabricks
 liquibase.ext.databricks.diff.output.changelog.MissingViewChangeGeneratorDatabricks
 liquibase.ext.databricks.diff.output.changelog.ChangedTableChangeGeneratorDatabricks
+liquibase.ext.databricks.diff.output.changelog.ChangedViewChangeGeneratorDatabricks

--- a/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
+++ b/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
@@ -1,0 +1,110 @@
+package liquibase.ext.databricks.diff.output.changelog;
+
+import liquibase.diff.Difference;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.ext.databricks.change.AbstractAlterPropertiesChangeDatabricks;
+import liquibase.structure.core.Table;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ChangedTblPropertiesUtilTest {
+
+    private final Table table = new Table("catalogName", "schemaName", "tableName");
+    private final DiffOutputControl control = new DiffOutputControl();
+
+    @Test
+    void justAdd() {
+        //Arrange
+        Difference difference = new Difference("tblProperties","'this.should.be.added'=35", "");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals("'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
+        assertEquals("", result.getUnsetExtendedTableProperties().getTblProperties());
+    }
+
+    @Test
+    void justRemove() {
+        //Arrange
+        Difference difference = new Difference("tblProperties", "", "'this.should.be.removed'=true");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals("", result.getSetExtendedTableProperties().getTblProperties());
+        assertEquals("'this.should.be.removed'", result.getUnsetExtendedTableProperties().getTblProperties());
+    }
+
+    @Test
+    void addAndRemoveAtSameTime() {
+        //Arrange
+        Difference difference = new Difference("tblProperties",
+                "'this.should.be.added'=35", "'this.should.be.removed'=true");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals("'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
+        assertEquals("'this.should.be.removed'", result.getUnsetExtendedTableProperties().getTblProperties());
+    }
+
+    @Test
+    void modify() {
+        //Arrange
+        Difference difference = new Difference("tblProperties",
+                "'this.should.be.changed'=35", "'this.should.be.changed'=20");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals("'this.should.be.changed'=35", result.getSetExtendedTableProperties().getTblProperties());
+        assertEquals("", result.getUnsetExtendedTableProperties().getTblProperties());
+    }
+
+    @Test
+    void ignore() {
+        //This case should not ever get to the Change Generator as there is no difference here
+        Difference difference = new Difference("tblProperties",
+                "'this.should.be.ignored'=35", "'this.should.be.ignored'=35");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals("", result.getSetExtendedTableProperties().getTblProperties());
+        assertEquals("", result.getUnsetExtendedTableProperties().getTblProperties());
+    }
+
+    @Test
+    void addAndRemoveAndChangeManyAtSameTimeAndInRandomOrder() {
+        //Arrange
+        Difference difference = new Difference("tblProperties",
+                "'this.should.be.ignored'=true,'this.should.be.added.too'=true,'this.should.be.added'=35,'this.should.be.changed'=true", "'this.should.be.changed'=false,'this.should.be.removed'='aaa','this.should.be.ignored'=true,this.should.be.removed.too'=bye");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals("'this.should.be.added.too'=true,'this.should.be.changed'=true,'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
+        assertEquals("'this.should.be.removed',this.should.be.removed.too'", result.getUnsetExtendedTableProperties().getTblProperties());
+    }
+}

--- a/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
+++ b/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
@@ -37,7 +37,7 @@ class ChangedTblPropertiesUtilTest {
         Difference difference = new Difference("tblProperties", "", "'this.should.be.removed'=true");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
@@ -54,7 +54,7 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.added'=35", "'this.should.be.removed'=true");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
@@ -73,7 +73,7 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.changed'=35", "'this.should.be.changed'=20");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
@@ -90,7 +90,7 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.ignored'=35", "'this.should.be.ignored'=35");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
@@ -105,7 +105,7 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.ignored'=true,'this.should.be.added.too'=true,'this.should.be.added'=35,'this.should.be.changed'=true", "'this.should.be.changed'=false,'this.should.be.removed'='aaa','this.should.be.ignored'=true,this.should.be.removed.too'=bye");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
@@ -114,6 +114,26 @@ class ChangedTblPropertiesUtilTest {
         assertEquals("'this.should.be.added.too'=true,'this.should.be.changed'=true,'this.should.be.added'=35", result[0].getSetExtendedTableProperties().getTblProperties());
         assertNull(result[0].getUnsetExtendedTableProperties());
         assertEquals("'this.should.be.removed',this.should.be.removed.too'", result[1].getUnsetExtendedTableProperties().getTblProperties());
+        assertNull(result[1].getSetExtendedTableProperties());
+    }
+
+    @Test
+    void ignoreInternalDeltaProperties() {
+        //Arrange
+        Difference difference = new Difference("tblProperties",
+                "'delta.columnMapping.maxColumnId'=35, 'this.should.be.added.too'=true",
+                "'this.should.be.dropped'=false, 'delta.feature.clustering'=20");
+
+        //Act
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
+                .getAlterTablePropertiesChangeDatabricks(table, control, difference);
+
+        //Assert
+        assertNotNull(result);
+        assertEquals(2, result.length);
+        assertEquals("'this.should.be.added.too'=true", result[0].getSetExtendedTableProperties().getTblProperties());
+        assertNull(result[0].getUnsetExtendedTableProperties());
+        assertEquals("'this.should.be.dropped'", result[1].getUnsetExtendedTableProperties().getTblProperties());
         assertNull(result[1].getSetExtendedTableProperties());
     }
 }

--- a/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
+++ b/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
@@ -3,6 +3,7 @@ package liquibase.ext.databricks.diff.output.changelog;
 import liquibase.diff.Difference;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.ext.databricks.change.AbstractAlterPropertiesChangeDatabricks;
+import liquibase.ext.databricks.change.alterTableProperties.AlterTablePropertiesChangeDatabricks;
 import liquibase.structure.core.Table;
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +20,15 @@ class ChangedTblPropertiesUtilTest {
         Difference difference = new Difference("tblProperties","'this.should.be.added'=35", "");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks[] result = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
         assertNotNull(result);
-        assertEquals("'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
-        assertNull(result.getUnsetExtendedTableProperties());
+        assertEquals(1, result.length);
+        assertEquals(table.getName(), ((AlterTablePropertiesChangeDatabricks)result[0]).getTableName());
+        assertEquals("'this.should.be.added'=35", result[0].getSetExtendedTableProperties().getTblProperties());
+        assertNull(result[0].getUnsetExtendedTableProperties());
     }
 
     @Test
@@ -34,13 +37,14 @@ class ChangedTblPropertiesUtilTest {
         Difference difference = new Difference("tblProperties", "", "'this.should.be.removed'=true");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
         assertNotNull(result);
-        assertNull(result.getSetExtendedTableProperties());
-        assertEquals("'this.should.be.removed'", result.getUnsetExtendedTableProperties().getTblProperties());
+        assertEquals(1, result.length);
+        assertNull(result[0].getSetExtendedTableProperties());
+        assertEquals("'this.should.be.removed'", result[0].getUnsetExtendedTableProperties().getTblProperties());
     }
 
     @Test
@@ -50,13 +54,16 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.added'=35", "'this.should.be.removed'=true");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
         assertNotNull(result);
-        assertEquals("'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
-        assertEquals("'this.should.be.removed'", result.getUnsetExtendedTableProperties().getTblProperties());
+        assertEquals(2, result.length);
+        assertEquals("'this.should.be.added'=35", result[0].getSetExtendedTableProperties().getTblProperties());
+        assertNull(result[0].getUnsetExtendedTableProperties());
+        assertEquals("'this.should.be.removed'", result[1].getUnsetExtendedTableProperties().getTblProperties());
+        assertNull(result[1].getSetExtendedTableProperties());
     }
 
     @Test
@@ -66,13 +73,14 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.changed'=35", "'this.should.be.changed'=20");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
         assertNotNull(result);
-        assertEquals("'this.should.be.changed'=35", result.getSetExtendedTableProperties().getTblProperties());
-        assertNull(result.getUnsetExtendedTableProperties());
+        assertEquals(1, result.length);
+        assertEquals("'this.should.be.changed'=35", result[0].getSetExtendedTableProperties().getTblProperties());
+        assertNull(result[0].getUnsetExtendedTableProperties());
     }
 
     @Test
@@ -82,13 +90,12 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.ignored'=35", "'this.should.be.ignored'=35");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
         assertNotNull(result);
-        assertNull(result.getSetExtendedTableProperties());
-        assertNull(result.getUnsetExtendedTableProperties());
+        assertEquals(0, result.length);
     }
 
     @Test
@@ -98,12 +105,15 @@ class ChangedTblPropertiesUtilTest {
                 "'this.should.be.ignored'=true,'this.should.be.added.too'=true,'this.should.be.added'=35,'this.should.be.changed'=true", "'this.should.be.changed'=false,'this.should.be.removed'='aaa','this.should.be.ignored'=true,this.should.be.removed.too'=bye");
 
         //Act
-        AbstractAlterPropertiesChangeDatabricks result = ChangedTblPropertiesUtil
+        AbstractAlterPropertiesChangeDatabricks result[] = ChangedTblPropertiesUtil
                 .getAlterTablePropertiesChangeDatabricks(table, control, difference);
 
         //Assert
         assertNotNull(result);
-        assertEquals("'this.should.be.added.too'=true,'this.should.be.changed'=true,'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
-        assertEquals("'this.should.be.removed',this.should.be.removed.too'", result.getUnsetExtendedTableProperties().getTblProperties());
+        assertEquals(2, result.length);
+        assertEquals("'this.should.be.added.too'=true,'this.should.be.changed'=true,'this.should.be.added'=35", result[0].getSetExtendedTableProperties().getTblProperties());
+        assertNull(result[0].getUnsetExtendedTableProperties());
+        assertEquals("'this.should.be.removed',this.should.be.removed.too'", result[1].getUnsetExtendedTableProperties().getTblProperties());
+        assertNull(result[1].getSetExtendedTableProperties());
     }
 }

--- a/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
+++ b/src/test/java/liquibase/ext/databricks/diff/output/changelog/ChangedTblPropertiesUtilTest.java
@@ -6,8 +6,7 @@ import liquibase.ext.databricks.change.AbstractAlterPropertiesChangeDatabricks;
 import liquibase.structure.core.Table;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ChangedTblPropertiesUtilTest {
 
@@ -26,7 +25,7 @@ class ChangedTblPropertiesUtilTest {
         //Assert
         assertNotNull(result);
         assertEquals("'this.should.be.added'=35", result.getSetExtendedTableProperties().getTblProperties());
-        assertEquals("", result.getUnsetExtendedTableProperties().getTblProperties());
+        assertNull(result.getUnsetExtendedTableProperties());
     }
 
     @Test
@@ -40,7 +39,7 @@ class ChangedTblPropertiesUtilTest {
 
         //Assert
         assertNotNull(result);
-        assertEquals("", result.getSetExtendedTableProperties().getTblProperties());
+        assertNull(result.getSetExtendedTableProperties());
         assertEquals("'this.should.be.removed'", result.getUnsetExtendedTableProperties().getTblProperties());
     }
 
@@ -73,7 +72,7 @@ class ChangedTblPropertiesUtilTest {
         //Assert
         assertNotNull(result);
         assertEquals("'this.should.be.changed'=35", result.getSetExtendedTableProperties().getTblProperties());
-        assertEquals("", result.getUnsetExtendedTableProperties().getTblProperties());
+        assertNull(result.getUnsetExtendedTableProperties());
     }
 
     @Test
@@ -88,8 +87,8 @@ class ChangedTblPropertiesUtilTest {
 
         //Assert
         assertNotNull(result);
-        assertEquals("", result.getSetExtendedTableProperties().getTblProperties());
-        assertEquals("", result.getUnsetExtendedTableProperties().getTblProperties());
+        assertNull(result.getSetExtendedTableProperties());
+        assertNull(result.getUnsetExtendedTableProperties());
     }
 
     @Test


### PR DESCRIPTION
 
- Added `ChangedTableChangeGeneratorDatabricks` class to handle Databricks-specific table property changes.
- Implemented logic to compare and generate changes for table properties.
- Updated `META-INF/services/liquibase.diff.output.changelog.ChangeGenerator` to include the new change generator.