### PR TITLE
fix(DAT-18966): hide delta properties for tables/views

### DIFF
--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingTableChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingTableChangeGeneratorDatabricks.java
@@ -12,6 +12,8 @@ import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Table;
 
+import static liquibase.ext.databricks.diff.output.changelog.ChangedTblPropertiesUtil.getExtendedProperties;
+
 public class MissingTableChangeGeneratorDatabricks extends MissingTableChangeGenerator {
 
     @Override
@@ -33,7 +35,7 @@ public class MissingTableChangeGeneratorDatabricks extends MissingTableChangeGen
         //so far we intentionally omit tableLocation in generated changelog
         ExtendedTableProperties extendedTableProperties = new ExtendedTableProperties(
                 null,
-                missingObject.getAttribute("tblProperties", String.class));
+                getExtendedProperties(missingObject.getAttribute("tblProperties", String.class)));
         String clusterColumns = missingObject.getAttribute("clusteringColumns", "");
 
         changes[0] = getCreateTableChangeDatabricks(extendedTableProperties, changes, clusterColumns);

--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingViewChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingViewChangeGeneratorDatabricks.java
@@ -11,6 +11,8 @@ import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.View;
 
+import static liquibase.ext.databricks.diff.output.changelog.ChangedTblPropertiesUtil.getExtendedProperties;
+
 /**
  * Custom implementation of {@link MissingViewChangeGenerator} for Databricks.
  */
@@ -31,7 +33,7 @@ public class MissingViewChangeGeneratorDatabricks extends MissingViewChangeGener
         if (changes == null || changes.length == 0) {
             return changes;
         }
-        changes[0] = getCreateViewChangeDatabricks(missingObject.getAttribute("tblProperties", String.class), changes);
+        changes[0] = getCreateViewChangeDatabricks(getExtendedProperties(missingObject.getAttribute("tblProperties", String.class)), changes);
         return changes;
     }
 


### PR DESCRIPTION
fix: delta properties for tables/views should not be present in the extendedTableProperties changeSet for generated changelogs and diff-changelog when referenceDB is empty.