### PR TITLE
[no_jira] fixed processing null Changes in MissingColumnChangeGeneratorDatabricks

### DIFF
--- a/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingColumnChangeGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/diff/output/changelog/MissingColumnChangeGeneratorDatabricks.java
@@ -38,8 +38,7 @@ public class MissingColumnChangeGeneratorDatabricks extends MissingColumnChangeG
     @Override
     public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         Change[] changes = super.fixMissing(missingObject, control, referenceDatabase, comparisonDatabase, chain);
-        changes = handleMissingColumnConstraints((Column) missingObject, control, changes);
-        return changes;
+        return changes == null ? null : handleMissingColumnConstraints((Column) missingObject, control, changes);
     }
 
     private Change[] handleMissingColumnConstraints(Column column, DiffOutputControl control, Change[] changes) {


### PR DESCRIPTION
Super class returns null for views, need to count that in Databricks class

MissingColumnChangeGenerator.fixMissing()
```        
if (column.getRelation() instanceof View) {
            return null;
        }
```
