### PR TITLE
DAT-18731 - Resolving the /null problem when not finding the createTable.sql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <sonar.qualitygate.wait>true</sonar.qualitygate.wait>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.tests>src/test</sonar.tests>
-        <liquibase-test-harness.version>1.1.0-SNAPSHOT</liquibase-test-harness.version>
+        <liquibase-test-harness.version>1.0.10</liquibase-test-harness.version>
         <junit.version>5.11.4</junit.version>
         <junit-platform.version>1.11.4</junit-platform.version>
         <mockito.version>5.14.2</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,12 +137,6 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-suite-api</artifactId>
-            <version>1.11.3</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <sonar.qualitygate.wait>true</sonar.qualitygate.wait>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.tests>src/test</sonar.tests>
-        <liquibase-test-harness.version>1.0.10</liquibase-test-harness.version>
+        <liquibase-test-harness.version>1.1.0-SNAPSHOT</liquibase-test-harness.version>
         <junit.version>5.11.4</junit.version>
         <junit-platform.version>1.11.4</junit-platform.version>
         <mockito.version>5.14.2</mockito.version>
@@ -135,6 +135,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite-api</artifactId>
+            <version>1.11.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/liquibase/ext/databricks/AdvancedExtensionHarnessTestSuite.java
+++ b/src/test/java/liquibase/ext/databricks/AdvancedExtensionHarnessTestSuite.java
@@ -1,9 +1,10 @@
 package liquibase.ext.databricks;
 
 import liquibase.harness.AdvancedHarnessSuite;
+import liquibase.harness.generateChangelog.GenerateChangelogTest;
 import liquibase.harness.snapshot.SnapshotObjectTests;
 import org.junit.platform.suite.api.SelectClasses;
 
-@SelectClasses({SnapshotObjectTests.class})
+@SelectClasses({SnapshotObjectTests.class, GenerateChangelogTest.class})
 public class AdvancedExtensionHarnessTestSuite extends AdvancedHarnessSuite {
 }

--- a/src/test/java/liquibase/ext/databricks/AdvancedExtensionHarnessTestSuite.java
+++ b/src/test/java/liquibase/ext/databricks/AdvancedExtensionHarnessTestSuite.java
@@ -5,6 +5,6 @@ import liquibase.harness.generateChangelog.GenerateChangelogTest;
 import liquibase.harness.snapshot.SnapshotObjectTests;
 import org.junit.platform.suite.api.SelectClasses;
 
-@SelectClasses({SnapshotObjectTests.class, GenerateChangelogTest.class})
+@SelectClasses({SnapshotObjectTests.class})
 public class AdvancedExtensionHarnessTestSuite extends AdvancedHarnessSuite {
 }

--- a/src/test/resources/liquibase/harness/generateChangelog/expectedChangeLog/databricks/createTable.sql
+++ b/src/test/resources/liquibase/harness/generateChangelog/expectedChangeLog/databricks/createTable.sql
@@ -1,1 +1,0 @@
-CREATE TABLE test_table_xml (test_column INT);

--- a/src/test/resources/liquibase/harness/generateChangelog/expectedSql/databricks/createTable.sql
+++ b/src/test/resources/liquibase/harness/generateChangelog/expectedSql/databricks/createTable.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test_table_xml (test_column INT) USING delta TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported', 'delta.columnMapping.mode' = 'name', 'delta.enableDeletionVectors' = true);


### PR DESCRIPTION
## Problem:
The system was encountering a `/null` path issue when attempting to locate the createTable.sql file, affecting the test reliability.

## Solution
- Modified the cleanup mechanism in `GenerateChangelogTest` to correctly target and remove generated files in the `src/test/resources/generated/` directory
- Implemented a pre-test cleanup routine to ensure a clean state before test execution
- Fixed the path resolution logic for SQL file lookup

## Evidence
The test execution now shows successful cleanup operations:

<img width="999" alt="image" src="https://github.com/user-attachments/assets/05f4fca7-3f14-4a02-9021-fee68841f386" />
