### PR TITLE
use ubuntu-22.04 to run databricks

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   liquibase-test-harness:
     name: Liquibase Test Harness
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Liquibase-Databricks Connector
 
 


### PR DESCRIPTION
This pull request includes changes to update the GitHub Actions workflow to include `ubuntu-22.04`. 
Seems like there is an issue with using `ubuntu-latest` ie `Ubuntu 24.10` for databricks. 

Workflow updates:

* [`.github/workflows/lth.yml`](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003L17-R17): Updated the `runs-on` key from `ubuntu-latest` to `ubuntu-22.04` to ensure compatibility with the latest Ubuntu version.