### PR TITLE
fix: add missing replaces method for Snapshot Generator

### DIFF
--- a/src/main/java/liquibase/ext/databricks/snapshot/jvm/SchemaSnapshotGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/snapshot/jvm/SchemaSnapshotGeneratorDatabricks.java
@@ -5,6 +5,7 @@ import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.ext.databricks.database.DatabricksDatabase;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.SchemaSnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.util.JdbcUtil;
@@ -36,6 +37,11 @@ public class SchemaSnapshotGeneratorDatabricks extends SchemaSnapshotGenerator {
         }
 
         return returnList.toArray(new String[0]);
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{SchemaSnapshotGenerator.class};
     }
 
 }

--- a/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/snapshot/jvm/TableSnapshotGeneratorDatabricks.java
@@ -7,6 +7,7 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.TableSnapshotGenerator;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -155,6 +156,11 @@ public class TableSnapshotGeneratorDatabricks extends TableSnapshotGenerator {
     private String sanitizeClusterColumns(String clusterColumnProperty) {
         Pattern pattern = Pattern.compile("[\\[\\]\\\"]");
         return clusterColumnProperty.replaceAll(pattern.toString(), "");
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{TableSnapshotGenerator.class};
     }
 
 }

--- a/src/main/java/liquibase/ext/databricks/snapshot/jvm/ViewSnapshotGeneratorDatabricks.java
+++ b/src/main/java/liquibase/ext/databricks/snapshot/jvm/ViewSnapshotGeneratorDatabricks.java
@@ -8,6 +8,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.ext.databricks.database.DatabricksDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.ViewSnapshotGenerator;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -87,5 +88,10 @@ public class ViewSnapshotGeneratorDatabricks extends ViewSnapshotGenerator {
             csvString.append("'").append(tableProperty.get("KEY")).append("'='").append(tableProperty.get("VALUE")).append("', ")
         );
         return csvString.toString().replaceAll(", $", "");
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{ViewSnapshotGenerator.class};
     }
 }


### PR DESCRIPTION
liquibase/liquibase#5775 was merged and fixed a bug where some snapshot generators were not being called.
But it also highlighted one issue at least in one OSS extension: if then extension replaces a core generator but is not implementing the replaces method, both generators may be invoked now.

This PR implements the missing replaces method.