### PR TITLE
Fix/stop databases workflow

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -58,8 +58,8 @@ jobs:
           path: src/test/terraform/terraform.tfstate
         
   liquibase-test-harness:
-    if: false
     name: Liquibase Test Harness
+    if: false
     runs-on: ubuntu-22.04
     needs: start-test-harness-infra
     permissions:
@@ -152,22 +152,13 @@ jobs:
     needs: start-test-harness-infra
     if: always() # Always destroy, even if the previous steps fail
     runs-on: ubuntu-22.04
-    permissions:
-      checks: write
-      pull-requests: write
-      contents: write
-    env:
-      TF_VAR_DBX_HOST: ${{ secrets.TH_DATABRICKS_WORKSPACE_HOST }}
-      TF_VAR_DBX_TOKEN: ${{ secrets.TH_DATABRICKS_WORKSPACE_TOKEN }}
-      TF_VAR_TEST_CATALOG: main
-      TF_VAR_TEST_SCHEMA: liquibase_harness_test_ds
-
+    # permissions:
+    #   checks: write
+    #   pull-requests: write
+    #   contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: Set up Databricks CLI
-        uses: databricks/setup-cli@main
 
       - run: terraform init
         working-directory: src/test/terraform
@@ -181,7 +172,6 @@ jobs:
       - name: Stop test database
         working-directory: src/test/terraform
         run: |
-          set -e
           echo "Checking Terraform-managed resources"
           terraform state list || echo "No resources in Terraform state."
 
@@ -191,21 +181,6 @@ jobs:
           if [ -z "$TERRAFORM_OUTPUT" ]; then
             echo "Terraform state is empty. Skipping terraform destroy."
           else
-            SCHEMA_EXISTS=$(echo "$TERRAFORM_OUTPUT" | jq -r '
-              [
-                .values.root_module.resources[]?,
-                (.values.root_module.child_modules[]?.resources[]?)
-              ]
-              | map(select(.address == "databricks_schema.test_harness"))
-              | .[0].values.name // ""
-            ')
-
-            if [ "$SCHEMA_EXISTS" == "liquibase_harness_test_ds" ]; then
               echo "Schema found in Terraform state. Destroying"
-              terraform destroy -auto-approve
-            else
-              echo "Schema not found in Terraform state. Attempting manual deletion"
-              databricks schema delete --catalog-name main --schema-name liquibase_harness_test_ds
-              echo "Manual deletion failed. Schema may not exist or is already deleted."
-            fi
+              terraform destroy -auto-approve 
           fi

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   start-test-harness-infra:
-    if: false
     name: Start Liquibase Test Harness infra
     runs-on: ubuntu-22.04
     permissions:
@@ -52,6 +51,12 @@ jobs:
           DATABRICKS_HOST=${TF_VAR_DBX_HOST#https://}
           echo "DATABRICKS_URL=jdbc:databricks://$DATABRICKS_HOST:443/default;transportMode=http;ssl=1;httpPath=/sql/1.0/warehouses/$CLUSTER_ID;AuthMech=3;ConnCatalog=$TF_VAR_TEST_CATALOG;ConnSchema=$TF_VAR_TEST_SCHEMA;EnableArrow=0" >> $GITHUB_OUTPUT
 
+      - name: Upload the terraform state file
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-state
+          path: src/test/terraform/terraform.tfstate
+        
   liquibase-test-harness:
     if: false
     name: Liquibase Test Harness
@@ -166,6 +171,12 @@ jobs:
       - run: terraform init
         working-directory: src/test/terraform
 
+      - name: Download the terraform state file
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-state
+          path: src/test/terraform
+
       - name: Stop test database
         working-directory: src/test/terraform
         run: |
@@ -175,7 +186,7 @@ jobs:
           terraform state list || echo "No resources in Terraform state."
 
           echo "Fetching Terraform state as JSON"
-          TERRAFORM_OUTPUT="$(terraform show -json)"
+          TERRAFORM_OUTPUT=$(terraform show -json)
 
           if [ -z "$TERRAFORM_OUTPUT" ]; then
             echo "Terraform state is empty. Skipping terraform destroy."

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   start-test-harness-infra:
+    if: false
     name: Start Liquibase Test Harness infra
     runs-on: ubuntu-22.04
     permissions:
@@ -52,6 +53,7 @@ jobs:
           echo "DATABRICKS_URL=jdbc:databricks://$DATABRICKS_HOST:443/default;transportMode=http;ssl=1;httpPath=/sql/1.0/warehouses/$CLUSTER_ID;AuthMech=3;ConnCatalog=$TF_VAR_TEST_CATALOG;ConnSchema=$TF_VAR_TEST_SCHEMA;EnableArrow=0" >> $GITHUB_OUTPUT
 
   liquibase-test-harness:
+    if: false
     name: Liquibase Test Harness
     runs-on: ubuntu-22.04
     needs: start-test-harness-infra
@@ -141,7 +143,7 @@ jobs:
 
   stop-test-harness-infra:
     name: Stop Liquibase Test Harness infra
-    needs: [liquibase-test-harness]
+    # needs: [liquibase-test-harness]
     if: always() # Always destroy, even if the previous steps fail
     runs-on: ubuntu-22.04
     permissions:
@@ -173,7 +175,7 @@ jobs:
           terraform state list || echo "No resources in Terraform state."
 
           echo "Fetching Terraform state as JSON"
-          TERRAFORM_OUTPUT=$(terraform show -json)
+          TERRAFORM_OUTPUT="$(terraform show -json)"
 
           if [ -z "$TERRAFORM_OUTPUT" ]; then
             echo "Terraform state is empty. Skipping terraform destroy."

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -149,6 +149,7 @@ jobs:
   stop-test-harness-infra:
     name: Stop Liquibase Test Harness infra
     # needs: [liquibase-test-harness]
+    needs: start-test-harness-infra
     if: always() # Always destroy, even if the previous steps fail
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -166,22 +166,13 @@ jobs:
         run: |
           set -e
           TERRAFORM_OUTPUT=$(terraform show -json)
-          
           if [ -z "$TERRAFORM_OUTPUT" ]; then
             echo "Terraform output is empty. Skipping removal."
           else
-            SCHEMA_EXISTS=$(echo "$TERRAFORM_OUTPUT" | jq -r '
-              [
-                .values.root_module.resources[]?,
-                (.values.root_module.child_modules[]?.resources[]?)
-              ] 
-              | map(select(.address == "databricks_schema.test_harness")) 
-              | .[0].values.name // ""
-            ')
-          
+            SCHEMA_EXISTS=$(echo $TERRAFORM_OUTPUT | jq -r '.values.root_module.resources[] | select(.address == "databricks_schema.test_harness") | .values.name')
             if [ "$SCHEMA_EXISTS" == "liquibase_harness_test_ds" ]; then
               terraform destroy -auto-approve
             else
-              echo "Schema does not exist in Terraform state. Skipping removal."
+              echo "Schema does not exist. Skipping removal."
             fi
           fi

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -59,7 +59,6 @@ jobs:
         
   liquibase-test-harness:
     name: Liquibase Test Harness
-    if: false
     runs-on: ubuntu-22.04
     needs: start-test-harness-infra
     permissions:
@@ -148,8 +147,7 @@ jobs:
 
   stop-test-harness-infra:
     name: Stop Liquibase Test Harness infra
-    # needs: [liquibase-test-harness]
-    needs: start-test-harness-infra
+    needs: [liquibase-test-harness]
     if: always() # Always destroy, even if the previous steps fail
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -161,10 +161,6 @@ jobs:
       - name: Set up Databricks CLI
         uses: databricks/setup-cli@main
 
-      - name: Authenticate Databricks CLI 
-        run: |
-          databricks auth login --host "$TF_VAR_DBX_HOST" --token "$TF_VAR_DBX_TOKEN"
-
       - run: terraform init
         working-directory: src/test/terraform
 

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -183,7 +183,6 @@ jobs:
         run: |
           set -e
           echo "Checking Terraform-managed resources"
-          terraform init
           terraform state list || echo "No resources in Terraform state."
 
           echo "Fetching Terraform state as JSON"
@@ -205,8 +204,8 @@ jobs:
               echo "Schema found in Terraform state. Destroying"
               terraform destroy -auto-approve
             else
-              echo "Schema not found in Terraform state. Attempting manual deletion
-              databricks schema delete --catalog-name main --schema-name liquibase_harness_test_ds || \
+              echo "Schema not found in Terraform state. Attempting manual deletion"
+              databricks schema delete --catalog-name main --schema-name liquibase_harness_test_ds
               echo "Manual deletion failed. Schema may not exist or is already deleted."
             fi
           fi

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -152,10 +152,16 @@ jobs:
     needs: start-test-harness-infra
     if: always() # Always destroy, even if the previous steps fail
     runs-on: ubuntu-22.04
-    # permissions:
-    #   checks: write
-    #   pull-requests: write
-    #   contents: write
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: write
+    env:
+      TF_VAR_DBX_HOST: ${{ secrets.TH_DATABRICKS_WORKSPACE_HOST }}
+      TF_VAR_DBX_TOKEN: ${{ secrets.TH_DATABRICKS_WORKSPACE_TOKEN }}
+      TF_VAR_TEST_CATALOG: main
+      TF_VAR_TEST_SCHEMA: liquibase_harness_test_ds
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -172,6 +178,7 @@ jobs:
       - name: Stop test database
         working-directory: src/test/terraform
         run: |
+          set -e
           echo "Checking Terraform-managed resources"
           terraform state list || echo "No resources in Terraform state."
 

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -157,6 +157,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Set up Databricks CLI
+        uses: databricks/setup-cli@main
+
+      - name: Authenticate Databricks CLI 
+        run: |
+          databricks auth login --host "$TF_VAR_DBX_HOST" --token "$TF_VAR_DBX_TOKEN"
 
       - run: terraform init
         working-directory: src/test/terraform
@@ -165,14 +172,31 @@ jobs:
         working-directory: src/test/terraform
         run: |
           set -e
+          echo "Checking Terraform-managed resources"
+          terraform init
+          terraform state list || echo "No resources in Terraform state."
+
+          echo "Fetching Terraform state as JSON"
           TERRAFORM_OUTPUT=$(terraform show -json)
+
           if [ -z "$TERRAFORM_OUTPUT" ]; then
-            echo "Terraform output is empty. Skipping removal."
+            echo "Terraform state is empty. Skipping terraform destroy."
           else
-            SCHEMA_EXISTS=$(echo $TERRAFORM_OUTPUT | jq -r '.values.root_module.resources[] | select(.address == "databricks_schema.test_harness") | .values.name')
+            SCHEMA_EXISTS=$(echo "$TERRAFORM_OUTPUT" | jq -r '
+              [
+                .values.root_module.resources[]?,
+                (.values.root_module.child_modules[]?.resources[]?)
+              ]
+              | map(select(.address == "databricks_schema.test_harness"))
+              | .[0].values.name // ""
+            ')
+
             if [ "$SCHEMA_EXISTS" == "liquibase_harness_test_ds" ]; then
+              echo "Schema found in Terraform state. Destroying"
               terraform destroy -auto-approve
             else
-              echo "Schema does not exist. Skipping removal."
+              echo "Schema not found in Terraform state. Attempting manual deletion
+              databricks schema delete --catalog-name main --schema-name liquibase_harness_test_ds || \
+              echo "Manual deletion failed. Schema may not exist or is already deleted."
             fi
           fi


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflow configuration in the `.github/workflows/lth.yml` file. The changes focus on improving artifact handling, modifying job dependencies, and enhancing the cleanup process.

### Artifact Handling Improvements:
* Added steps to upload and download the Terraform state file using `actions/upload-artifact@v4` and `actions/download-artifact@v4` respectively. [[1]](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003R54-R61) [[2]](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003R169-R192)

### Job Dependency Modifications:
* Commented out the dependency on `liquibase-test-harness` for the `stop-test-harness-infra` job and added a dependency on `start-test-harness-infra`.

### Cleanup Process Enhancements:
* Added steps to check Terraform-managed resources and fetch the Terraform state as JSON before attempting to destroy resources.
* Modified the cleanup process to attempt manual schema deletion using the Databricks CLI if the schema is not found in the Terraform state.