### PR TITLE
chore: update GitHub token usage

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -68,7 +68,6 @@ jobs:
       packages: write
     env:
       WORKSPACE_ID: ${{ secrets.TH_DATABRICKS_WORKSPACE_ID }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_VAR_DBX_TOKEN: ${{ secrets.TH_DATABRICKS_WORKSPACE_TOKEN }}
     strategy:
       max-parallel: 1
@@ -119,12 +118,10 @@ jobs:
             [
               {
                 "id": "liquibase-pro",
-                "username": "liquibot",
                 "password": "${{ secrets.GITHUB_TOKEN }}"
               },
               {
                 "id": "liquibase",
-                "username": "liquibot",
                 "password": "${{ secrets.GITHUB_TOKEN }}"
               }
             ]


### PR DESCRIPTION
This pull request updates the `.github/workflows/lth.yml` file to modify authentication methods and permissions in the workflow configuration. The most important changes involve replacing secret tokens and adding package write permissions.

### Workflow Authentication Updates:
* Replaced `LIQUIBOT_TOKEN` and `GITHUB_TOKEN` with a single `GITHUB_TOKEN` for authentication in the workflow configuration. (`[[1]](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003R68-L71)`, `[[2]](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003L122-R125)`)

### Workflow Permission Updates:
* Added `packages: write` permission to the workflow, enabling write access to GitHub packages. (`[.github/workflows/lth.ymlR68-L71](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003R68-L71)`)