### PR TITLE
🔧 DAT-20155: use actions/create-github-app-token

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -129,11 +129,11 @@ jobs:
             ]
 
       - name: Build with Maven # Build the code with Maven (skip tests)
-        run: mvn -B -ntp -Dmaven.test.skip package -Dliquibase.version=master-SNAPSHOT
+        run: mvn -B -Dmaven.test.skip package -Dliquibase.version=master-SNAPSHOT
 
       - name: Run ${{ matrix.liquibase-support-level }} Liquibase Test Harness # Run the Liquibase test harness at each test level
         if: always() # Run the action even if the previous steps fail
-        run: mvn -B -ntp -DdbPassword=${{env.TF_VAR_DBX_TOKEN}} -DdbUrl='${{needs.start-test-harness-infra.outputs.DATABRICKS_URL}}' -Dtest=liquibase.ext.databricks.${{ matrix.liquibase-support-level }}ExtensionHarnessTestSuite test -Dliquibase.version=master-SNAPSHOT # Run the Liquibase test harness at each test level
+        run: mvn -B -DdbPassword=${{env.TF_VAR_DBX_TOKEN}} -DdbUrl='${{needs.start-test-harness-infra.outputs.DATABRICKS_URL}}' -Dtest=liquibase.ext.databricks.${{ matrix.liquibase-support-level }}ExtensionHarnessTestSuite test -Dliquibase.version=master-SNAPSHOT # Run the Liquibase test harness at each test level
 
       - name: Test Reporter # Generate a test report using the Test Reporter action
         uses: dorny/test-reporter@v2.0.0

--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -79,6 +79,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-packages: write
+
       - name: Setup Temurin Java 17
         uses: actions/setup-java@v4
         with:
@@ -119,12 +129,12 @@ jobs:
               {
                 "id": "liquibase-pro",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               },
               {
                 "id": "liquibase",
                 "username": "liquibot",
-                "password": "${{ secrets.GITHUB_TOKEN }}"
+                "password": "${{ steps.get-token.outputs.token }}"
               }
             ]
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/lth.yml` file to improve security and streamline the workflow by replacing the use of the default GitHub token with a GitHub App token and making minor adjustments to Maven commands.

### Workflow security improvements:
* Added a step to generate a GitHub App token using the `actions/create-github-app-token@v2` action. This token is configured with specific permissions (`read` for contents and `write` for packages) and uses secrets for the app ID and private key. (`[.github/workflows/lth.ymlR82-R91](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003R82-R91)`)
* Replaced the default `${{ secrets.GITHUB_TOKEN }}` with the newly generated GitHub App token (`${{ steps.get-token.outputs.token }}`) for authentication in the workflow. (`[.github/workflows/lth.ymlL122-R146](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003L122-R146)`)

### Minor workflow adjustments:
* Simplified Maven commands by removing the `-ntp` (no transfer progress) flag, which is redundant for non-interactive workflows. (`[.github/workflows/lth.ymlL122-R146](diffhunk://#diff-a8d9f8fb2a632e7abc6b1fce50c961566e33a18fefafa230c2ed93f4924df003L122-R146)`)