### PR TITLE
DAT-20404: update trigger of the job schedule

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -1,7 +1,6 @@
 name: Liquibase Test Harness
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/lth.yml` file. The change removes the `pull_request` trigger from the workflow configuration for the Liquibase Test Harness.

The QA Team want to have possibility to start the tests on workflow_dispacth and to run automatic builds only on merge to master for databricks. 