### PR TITLE
[DAT-22458] Downgrade packages permission to read in lth workflow

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -90,7 +90,7 @@ jobs:
       checks: write
       pull-requests: write
       contents: write
-      packages: write
+      packages: read
       id-token: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Downgrade `packages` permission from `write` to `read` in `lth.yml`
- The workflow only reads from GPM for Maven dependencies, doesn't publish

## Test plan
- [ ] LTH workflow still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)