### PR TITLE
refactor(ci): replace archived whelk-io with build-logic setup-maven-settings [DAT-22915]

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -125,47 +125,11 @@ jobs:
           distribution: temurin
           cache: "maven"
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
+      - name: Set up Maven settings.xml
+        uses: liquibase/build-logic/.github/actions/setup-maven-settings@main
         with:
-          repositories: |
-            [
-              {
-                "id": "liquibase",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase",
-                "releases": {
-                  "enabled": "false"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              },
-              {
-                "id": "liquibase-pro",
-                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
-                "releases": {
-                  "enabled": "false"
-                },
-                "snapshots": {
-                  "enabled": "true",
-                  "updatePolicy": "always"
-                }
-              }
-            ]
-          servers: |
-            [
-              {
-                "id": "liquibase-pro",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              },
-              {
-                "id": "liquibase",
-                "username": "liquibot",
-                "password": "${{ env.LIQUIBOT_PAT_GPM_ACCESS }}"
-              }
-            ]
+          gpm-token: ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}
+          releases-enabled: 'false'
 
       - name: Build with Maven # Build the code with Maven (skip tests)
         run: mvn -B -ntp -Dmaven.test.skip package -Dliquibase.version=master-SNAPSHOT


### PR DESCRIPTION
## Summary

Replace the single `whelk-io/maven-settings-xml-action` call site in `.github/workflows/lth.yml` with the new first-party composite action [`liquibase/build-logic/.github/actions/setup-maven-settings`](https://github.com/liquibase/build-logic/pull/557).

Jira: [DAT-22915](https://datical.atlassian.net/browse/DAT-22915)

## Why

`whelk-io/maven-settings-xml-action` was **archived 2026-01-02** and flagged during the DAT-22654 supply-chain audit.

## What changed

Simple-mode invocation, behavior preserved exactly:
- **Repositories:** `liquibase` + `liquibase-pro` GPM
- **Servers:** both `liquibot` + `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}`
- **`releases-enabled: 'false'`** — preserves snapshots-only behavior

## Blocked by

🚧 [**liquibase/build-logic#557**](https://github.com/liquibase/build-logic/pull/557) must merge first.

## Test plan

- [x] YAML parses cleanly
- [x] No remaining `whelk-io` references
- [x] `${{ env.LIQUIBOT_PAT_GPM_ACCESS }}` flows unchanged from pre-existing vault step
- [ ] CI green post-merge of liquibase/build-logic#557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-22915]: https://datical.atlassian.net/browse/DAT-22915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ