### PR TITLE
Release 5.0.3 (align version with Liquibase core)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.liquibase.ext</groupId>
   <artifactId>liquibase-databricks</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>5.0.3-SNAPSHOT</version>
   <name>Liquibase Extension: Databricks support</name>
   <description>Liquibase Extension for Databricks.</description>
   <url>https://github.com/liquibase/liquibase-databricks</url>


### PR DESCRIPTION
Adopts the unified OSS-extension versioning so `liquibase-databricks` releases in lockstep with Liquibase core. Bumps the project version from `1.5.0-SNAPSHOT` to `5.0.3-SNAPSHOT` (`liquibase.version` is already `5.0.3`).

Merging this fires **Create Release** (drafts/cleans up stale drafts) and **Attach Artifact to Release**, producing a signed `v5.0.3` draft. The draft is published manually afterward.