### PR TITLE
Fix release-published startup failure (grant actions:read)

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -10,7 +10,8 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
-  
+  actions: read
+
 jobs:
   release:
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main


### PR DESCRIPTION
The v5.0.3 `Release Extension to Sonatype` run failed at startup:

> The workflow is requesting 'actions: read', but is only allowed 'actions: none'.

build-logic's reusable `extension-release-published.yml` now declares `actions: read` (added in build-logic#622 for its "Get build-logic ref" step). A reusable workflow can't request a permission the caller didn't grant, so the caller must also grant `actions: read`. This adds it. No artifacts reached Maven Central; the deploy job never started.